### PR TITLE
95d1eb8 hat falschlicherweise 1pt zu -0.75 geändert

### DIFF
--- a/kartei.print.tex
+++ b/kartei.print.tex
@@ -27,11 +27,11 @@
       \path [use as bounding box] node [inner sep=0pt,outer sep=0pt] (A) {\box\AtBeginShipoutBox};
       \ifcard@useFrontgrid%
         %vertical lines
-        \draw[front grid] (\card@hoffset-.5\paperwidth-0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset-.5\paperwidth-0.75pt,\card@voffset+.5\paperheight);%
-        \draw[front grid] (\card@hoffset+.5\paperwidth+0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset+.5\paperwidth+0.75pt,\card@voffset+.5\paperheight);%
+        \draw[front grid] (\card@hoffset-.5\paperwidth+0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset-.5\paperwidth+0.75pt,\card@voffset+.5\paperheight);%
+        \draw[front grid] (\card@hoffset+.5\paperwidth-0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset+.5\paperwidth-0.75pt,\card@voffset+.5\paperheight);%
         % horizontal lines
-        \draw[front grid] (\card@hoffset-.5\paperwidth-0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset+.5\paperwidth+0.75pt,\card@voffset-.5\paperheight);%
-        \draw[front grid] (\card@hoffset-.5\paperwidth-0.75pt,\card@voffset+.5\paperheight) -- (\card@hoffset+.5\paperwidth+0.75pt,\card@voffset+.5\paperheight);%
+        \draw[front grid] (\card@hoffset-.5\paperwidth+0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset+.5\paperwidth-0.75pt,\card@voffset-.5\paperheight);%
+        \draw[front grid] (\card@hoffset-.5\paperwidth+0.75pt,\card@voffset+.5\paperheight) -- (\card@hoffset+.5\paperwidth-0.75pt,\card@voffset+.5\paperheight);%
       \fi%
     \end{tikzpicture}%
   }%
@@ -40,11 +40,11 @@
       \path [use as bounding box] node [inner sep=0pt,outer sep=0pt] (A) {\box\AtBeginShipoutBox};
       \ifcard@useReargrid%
         %vertical lines
-        \draw[rear grid] (\card@hoffset-.5\paperwidth-0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset-.5\paperwidth-0.75pt,\card@voffset+.5\paperheight);%
-        \draw[rear grid] (\card@hoffset+.5\paperwidth+0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset+.5\paperwidth+0.75pt,\card@voffset+.5\paperheight);%
+        \draw[rear grid] (\card@hoffset-.5\paperwidth+0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset-.5\paperwidth+0.75pt,\card@voffset+.5\paperheight);%
+        \draw[rear grid] (\card@hoffset+.5\paperwidth-0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset+.5\paperwidth-0.75pt,\card@voffset+.5\paperheight);%
         % horizontal lines
-        \draw[rear grid] (\card@hoffset-.5\paperwidth-0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset+.5\paperwidth+0.75pt,\card@voffset-.5\paperheight);%
-        \draw[rear grid] (\card@hoffset-.5\paperwidth-0.75pt,\card@voffset+.5\paperheight) -- (\card@hoffset+.5\paperwidth+0.75pt,\card@voffset+.5\paperheight);%
+        \draw[rear grid] (\card@hoffset-.5\paperwidth+0.75pt,\card@voffset-.5\paperheight) -- (\card@hoffset+.5\paperwidth-0.75pt,\card@voffset-.5\paperheight);%
+        \draw[rear grid] (\card@hoffset-.5\paperwidth+0.75pt,\card@voffset+.5\paperheight) -- (\card@hoffset+.5\paperwidth-0.75pt,\card@voffset+.5\paperheight);%
       \fi%
     \end{tikzpicture}%
   }%


### PR DESCRIPTION
Der Vorzeichenwechsel hat zu sich überlappende Ränder geführt. Hier wird das Vorzeichen korrigiert.